### PR TITLE
📦 Chore/#5 .eslintrc.json prettier 수정 및 gitattributes 파일 추가

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,8 +20,14 @@
     }
   ],
   "rules": {
-    "prettier/prettier": "error",
+    "prettier/prettier": [
+      "error",
+      {
+        "endOfLine": "auto"
+      }
+    ],
     "react/react-in-jsx-scope": "off"
   },
+
   "ignorePatterns": ["**/git-tools/"]
 }

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
## ❗ Issue Number or Link

-  #5 

## 🧰 변경 타입

- [ ] ✨ feat: 새로운 기능
- [ ] 🐛 fix: 버그 수정
- [ ] ♻️ refactor: 코드 리팩토링
- [ ] 🎨 design: CSS 등 사용자 UI 디자인 변경
- [ ] 💎 style: 코드 포맷팅, 코드 변경이 없는 경우
- [x] 📦 chore: 빌드 업무 수정, 패키지 매니저 설정, 자잘한 코드 수정
- [ ] 💬 comment: 주석 추가 및 변경
- [ ] 📚 docs: 문서 수정
- [ ] 🚑 !HOTFIX: 급하게 치명적인 버그를 고치는 경우
- [ ] 🚀 perf: 성능 개선

## 🔎 작업 내용

- 윈도우에서 프리티어 개행방식이 달라 Delete 'CR'이 뜨는 현상 수정했습니다.
- 현상 해결을 위해 .eslintrc.json 파일에 prettier 코드 수정하고 gitattributes 파일 추가했습니다. 
 ->  `* text=auto eol=lf`


### 수정 전

![image](https://github.com/user-attachments/assets/b57e5613-775f-4722-8366-ad26a2621a4d)

![image](https://github.com/user-attachments/assets/63587dd6-8ebb-4020-ab79-39b63a97461f)



### 수정 후 

![image](https://github.com/user-attachments/assets/87b8adb0-616f-40a8-94a3-44e209bcf23d)

![image](https://github.com/user-attachments/assets/8052e54b-84c9-4927-82a6-47e70278f69f)

-  수정 전에는 모든 코드마다  Delete 'CR' 린팅 발생했으나, 수정 후 Delete 'CR'이 제거되고 필요한 부분만 린팅 발생되는 것을 확인했습니다.


## 📢 주의 및 리뷰 요청

- 윈도우 측면에서 안되는 부분을 수정했기 때문에, 수정된 코드가 맥에서 문제가 생길 경우 알려주세요!

## 🔗 Reference

- 해당 테스크를 수행하며 참고한 Link를 모두 작성 (Reference)
