### PR TITLE
 📦-Chore/#7-Vercel-자동-배포-설정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,34 @@
+name: Deploy
+
+on:
+  push:
+    branches: ['develop']
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: pandoc/latex
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install mustache (to update the date)
+        run: apk add ruby && gem install mustache
+
+      - name: creates output
+        run: sh ./build.sh
+
+      - name: Pushes to another repository
+        id: push_directory
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.AUTO_ACTIONS }}
+        with:
+          source-directory: 'output'
+          destination-github-username: JANGSEYEONG
+          destination-repository-name: FANMIX
+          user-email: ${{ secrets.OFFICIAL_ACCOUNT_EMAIL }}
+          commit-message: ${{ github.event.commits[0].message }}
+          target-branch: develop
+
+      - name: Test get variable exported by push-to-another-repository
+        run: echo $DESTINATION_CLONED_DIRECTORY

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+cd ../
+mkdir output
+cp -R ./FANMIX-FE/* ./output
+cp -R ./output ./FANMIX-FE/


### PR DESCRIPTION
## ❗ Issue Number or Link

- #7 

## 🧰 변경 타입

- [ ] ✨ feat: 새로운 기능
- [ ] 🐛 fix: 버그 수정
- [ ] ♻️ refactor: 코드 리팩토링
- [ ] 🎨 design: CSS 등 사용자 UI 디자인 변경
- [ ] 💎 style: 코드 포맷팅, 코드 변경이 없는 경우
- [x] 📦 chore: 빌드 업무 수정, 패키지 매니저 설정, 자잘한 코드 수정
- [ ] 💬 comment: 주석 추가 및 변경
- [ ] 📚 docs: 문서 수정
- [ ] 🚑 !HOTFIX: 급하게 치명적인 버그를 고치는 경우
- [ ] 🚀 perf: 성능 개선

## 🔎 작업 내용

- `Organization Secret key` 생성
- `build.sh` 생성 : action flow 시 실행할 명령어
- `.github/workflows/deploy.yml` 생성 : develop branch에 push 시 개인 계정 repo로 자동 push

## 📢 주의 및 리뷰 요청

- Vercel의 Organization Repository 연동은 체험 기간 이후 유료 결제를 해야하는 문제가 있습니다.
- 개인 플랜은 무료기에, Organization Repository의 develop branch에 push 이벤트가 발생할 경우 개인 Repository의 develop branch에도 자동 push가 되게 연동하여 Vercel에 자동 배포가 되도록 했습니다.
- 잘 세팅되었는지 이 PR merge 후에 동작 확인이 필요합니다! 참고만 부탁드려요


## 🔗 Reference

- [https://velog.io/@rmaomina/organization-vercel-hobby-deploy](https://velog.io/@rmaomina/organization-vercel-hobby-deploy)
- [https://vanilla-van-6e4.notion.site/vercel-47312c7c2a9c492dbdabc40c47489cfa](https://www.notion.so/47312c7c2a9c492dbdabc40c47489cfa?pvs=21)
