### PR TITLE
✨ Feat/#33 탭 공용 컴포넌트 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@radix-ui/react-separator": "^1.1.0",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-switch": "^1.1.0",
+    "@radix-ui/react-tabs": "^1.1.0",
     "@radix-ui/react-toast": "^1.2.1",
     "@radix-ui/react-tooltip": "^1.1.2",
     "@tanstack/react-query": "^5.53.1",

--- a/src/app/[locale]/(main)/page.tsx
+++ b/src/app/[locale]/(main)/page.tsx
@@ -5,6 +5,8 @@ import { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 import { useTranslations } from 'next-intl';
 
+import SlideBarTabs from '@/components/common/tab/SlideBarTabs';
+
 export async function generateMetadata({
   params: { locale },
 }: {
@@ -20,10 +22,25 @@ export async function generateMetadata({
 // 메인 페이지
 export default function MainPage() {
   const t = useTranslations('main_page');
+
+  const tabs = [
+    {
+      value: '1',
+      label: '인기 글',
+      content: <div className="mt-2.5 w-full text-center">인기 글 내역</div>,
+    },
+    {
+      value: '2',
+      label: '인기 리뷰',
+      content: <div className="mt-2.5 w-full text-center">인기 리뷰 내역</div>,
+    },
+  ];
+
   return (
     <main id={DOM_IDS.CURRENT_SCROLL_PAGE} className="h-full w-full px-5 page-scrollable-container">
       <h1>{t('{nickName}님 안녕하세요', { nickName: 'tpdud' })}</h1>
-      <hr />
+
+      <SlideBarTabs tabs={tabs} defaultValue="1" />
       <h1 className="h-[3000px]">{t('{nickName}님 안녕하세요', { nickName: 'tpdud' })}</h1>
       <h2>블러어어</h2>
     </main>

--- a/src/components/common/tab/SlideBarTabs.tsx
+++ b/src/components/common/tab/SlideBarTabs.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { Loader2 } from 'lucide-react';
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+
+interface SlideBarTabsProps {
+  tabs: { value: string; label: string; content: React.ReactNode }[];
+  defaultValue: string;
+}
+
+// Active 탭 하단을 따라다니는 슬라이드가 있는 탭
+const SlideBarTabs = ({ tabs, defaultValue }: SlideBarTabsProps) => {
+  const [activeTab, setActiveTab] = useState(defaultValue);
+  const [sliderStyle, setSliderStyle] = useState({});
+  const [isSliderLoading, setIsSliderLoading] = useState(true); // 슬라이드가 위치 찾을 때 까지 스피너 표시
+  const tabsListRef = useRef<HTMLDivElement>(null);
+
+  const updateSliderStyle = useCallback(() => {
+    // shadcn/ui는 Radix UI를 기반으로 하며, Radix UI에서는 현재 활성화된 탭에 'data-state="active"' 속성을 부여
+    // -> `active`로 슬라이더 위치 구할 탭 찾기
+    const activeElement = tabsListRef.current?.querySelector(
+      `[data-state="active"]`,
+    ) as HTMLElement;
+
+    if (activeElement) {
+      // 활성 탭의 위치와 너비를 기반으로 슬라이더 스타일을 업데이트
+      setSliderStyle({
+        left: `${activeElement.offsetLeft}px`,
+        width: `${activeElement.offsetWidth}px`,
+        transition: 'all 0.3s ease',
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    const timerId = setTimeout(() => {
+      updateSliderStyle();
+    }, 0);
+
+    window.addEventListener('resize', updateSliderStyle);
+    setIsSliderLoading(false);
+    return () => {
+      clearTimeout(timerId);
+      window.removeEventListener('resize', updateSliderStyle);
+    };
+  }, [activeTab, updateSliderStyle]);
+
+  // #20240920.syjang, TODO: 임의로 Loader2 사용 -> 디자이너님이 스피너 정해주면 해당 스피너로 변경 예정
+  if (isSliderLoading) {
+    return (
+      <div className="flex h-40 items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-orange-500" />
+      </div>
+    );
+  }
+
+  return (
+    <Tabs defaultValue={defaultValue} className="w-full" onValueChange={setActiveTab}>
+      <TabsList className="relative w-full flex-center" ref={tabsListRef}>
+        {tabs.map((tab) => (
+          <TabsTrigger key={tab.value} className="flex-1" value={tab.value}>
+            {tab.label}
+          </TabsTrigger>
+        ))}
+        <div className="absolute bottom-[-1.4px] h-0.5 bg-orange-500" style={sliderStyle} />
+      </TabsList>
+      {tabs.map((tab) => (
+        <TabsContent key={tab.value} value={tab.value}>
+          {tab.content}
+        </TabsContent>
+      ))}
+    </Tabs>
+  );
+};
+
+export default SlideBarTabs;

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import * as React from 'react';
+import * as TabsPrimitive from '@radix-ui/react-tabs';
+
+import { cn } from '@/lib/utils';
+
+const Tabs = TabsPrimitive.Root;
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      'inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground',
+      className,
+    )}
+    {...props}
+  />
+));
+TabsList.displayName = TabsPrimitive.List.displayName;
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
+      className,
+    )}
+    {...props}
+  />
+));
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      'mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+      className,
+    )}
+    {...props}
+  />
+));
+TabsContent.displayName = TabsPrimitive.Content.displayName;
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -14,7 +14,8 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      'inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground',
+      'border-b-[0.7px] border-neutral-400',
+      'inline-flex h-10 items-center justify-center bg-transparent py-1 text-muted-foreground',
       className,
     )}
     {...props}
@@ -26,14 +27,19 @@ const TabsTrigger = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
 >(({ className, ...props }, ref) => (
-  <TabsPrimitive.Trigger
-    ref={ref}
-    className={cn(
-      'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
-      className,
-    )}
-    {...props}
-  />
+  <div className="w-full flex-center">
+    <TabsPrimitive.Trigger
+      ref={ref}
+      className={cn(
+        'inline-flex items-center justify-center whitespace-nowrap px-3 py-1.5 text-neutral-400 ring-offset-background transition-all body3-m',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+        'disabled:pointer-events-none disabled:opacity-50',
+        'data-[state=active]:text-orange-500 data-[state=active]:shadow-sm data-[state=active]:body3-sb',
+        className,
+      )}
+      {...props}
+    />
+  </div>
 ));
 TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
 
@@ -44,7 +50,7 @@ const TabsContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      'mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+      'ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
       className,
     )}
     {...props}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1620,6 +1620,21 @@
   dependencies:
     "@radix-ui/react-slot" "1.1.0"
 
+"@radix-ui/react-roving-focus@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.0.tgz#b30c59daf7e714c748805bfe11c76f96caaac35e"
+  integrity sha512-EA6AMGeq9AEeQDeSH0aZgG198qkfHSbvWTf1HvoDmOB5bBG/qTxjYMWUKMnYiV6J/iP/J8MEFSuB2zRU2n7ODA==
+  dependencies:
+    "@radix-ui/primitive" "1.1.0"
+    "@radix-ui/react-collection" "1.1.0"
+    "@radix-ui/react-compose-refs" "1.1.0"
+    "@radix-ui/react-context" "1.1.0"
+    "@radix-ui/react-direction" "1.1.0"
+    "@radix-ui/react-id" "1.1.0"
+    "@radix-ui/react-primitive" "2.0.0"
+    "@radix-ui/react-use-callback-ref" "1.1.0"
+    "@radix-ui/react-use-controllable-state" "1.1.0"
+
 "@radix-ui/react-scroll-area@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-scroll-area/-/react-scroll-area-1.1.0.tgz#50b24b0fc9ada151d176395bcf47b2ec68feada5"
@@ -1661,6 +1676,20 @@
     "@radix-ui/react-use-controllable-state" "1.1.0"
     "@radix-ui/react-use-previous" "1.1.0"
     "@radix-ui/react-use-size" "1.1.0"
+
+"@radix-ui/react-tabs@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-tabs/-/react-tabs-1.1.0.tgz#0a6db1caed56776a1176aae68532060e301cc1c0"
+  integrity sha512-bZgOKB/LtZIij75FSuPzyEti/XBhJH52ExgtdVqjCIh+Nx/FW+LhnbXtbCzIi34ccyMsyOja8T0thCzoHFXNKA==
+  dependencies:
+    "@radix-ui/primitive" "1.1.0"
+    "@radix-ui/react-context" "1.1.0"
+    "@radix-ui/react-direction" "1.1.0"
+    "@radix-ui/react-id" "1.1.0"
+    "@radix-ui/react-presence" "1.1.0"
+    "@radix-ui/react-primitive" "2.0.0"
+    "@radix-ui/react-roving-focus" "1.1.0"
+    "@radix-ui/react-use-controllable-state" "1.1.0"
 
 "@radix-ui/react-toast@^1.2.1":
   version "1.2.1"


### PR DESCRIPTION
## ❗ Issue Number or Link

- #33 

## 🧰 변경 타입

- [x] ✨ feat: 새로운 기능
- [ ] 🐛 fix: 버그 수정
- [ ] ♻️ refactor: 코드 리팩토링
- [ ] 🎨 design: CSS 등 사용자 UI 디자인 변경
- [ ] 💎 style: 코드 포맷팅, 코드 변경이 없는 경우
- [ ] 📦 chore: 빌드 업무 수정, 패키지 매니저 설정, 자잘한 코드 수정
- [ ] 💬 comment: 주석 추가 및 변경
- [ ] 📚 docs: 문서 수정
- [ ] 🚑 !HOTFIX: 급하게 치명적인 버그를 고치는 경우
- [ ] 🚀 perf: 성능 개선

## 🔎 작업 내용

- `shadcn/ui` 의 `tab` 컴포넌트의 색상 커스텀
- active 상태인 탭 하단을 따라다니는 슬라이드가 있는 `SlideBarTabs` 컴포넌트 추가

### 사용 방법

1. tab label, value, content 정의
```javascript
const tabs = [
    {
      value: '1',
      label: '인기 글',
      content: <div className="mt-2.5 w-full text-center">인기 글 내역</div>,
    },
    {
      value: '2',
      label: '인기 리뷰',
      content: <div className="mt-2.5 w-full text-center">인기 리뷰 내역</div>,
    },
  ];
```
2. jsx 구문에서 prop으로 tab 넘기면 끝
```javascript
<SlideBarTabs tabs={tabs} defaultValue="1" />
```

### 결과

#### 탭 2개일 때

https://github.com/user-attachments/assets/52f6c888-62d7-49e7-bf2e-a6a4fd816e60

### 탭 3개일 때

https://github.com/user-attachments/assets/22d6c562-c6ac-4c32-b1e5-8887b4adf725



## 📢 주의 및 리뷰 요청

- 메인페이지, 활동내역 부분에서 사용하면 됩니다.
<img width="623" alt="image" src="https://github.com/user-attachments/assets/ad855e8e-5449-4f1d-a9b7-065266c83e98">
<img width="283" alt="image" src="https://github.com/user-attachments/assets/53698d28-ea8d-4092-bc49-8014c8bc436f">

- SlideBar가 active 탭의 위치 계산 전에는 렌더링 되지 않는 문제가 있어, 슬라이드바가 표시될 때 까지 spinner를 표시했습니다. 아직 디자이너님께 스피너를 전달받지 못해 임의로 Loader2 돌렸습니다.

## 🔗 Reference

- 해당 테스크를 수행하며 참고한 Link를 모두 작성 (Reference)
