### PR TITLE
✨ Feat/#112 리뷰 생성/수정/삭제 시 전체리뷰 캐시데이터 수정하기

### DIFF
--- a/src/app/[locale]/(main)/influencer/[influencerId]/reviews/_hooks/useMyReview.ts
+++ b/src/app/[locale]/(main)/influencer/[influencerId]/reviews/_hooks/useMyReview.ts
@@ -4,22 +4,27 @@ import { useMyLatestReviewForInfluencer } from '@/hooks/queries/useReviewService
 import { REVIEW_MODE, type ReviewMode, type MyLatestReview } from '@/types/domain/reviewType';
 
 export const useMyReview = (influencerId: number) => {
-  const { data, isError, isLoading } = useMyLatestReviewForInfluencer(influencerId);
+  const { data, isError, isLoading, isSuccess } = useMyLatestReviewForInfluencer(influencerId);
   const [myLatestReviewData, setMyLatestReviewData] = useState<MyLatestReview | null>(null);
   const [reviewMode, setReviewMode] = useState<ReviewMode>(REVIEW_MODE.VIEW);
 
   // 최신 리뷰 결과에 따라 reviewMode 바꿔주기
   useEffect(() => {
-    if (data?.data) {
-      // 최근 리뷰가 있음 -> 15일이 지났든, 안지났든 뷰 모드로 + 내 리뷰 데이터 저장
-      setMyLatestReviewData(data.data);
-      setReviewMode(REVIEW_MODE.VIEW);
+    if (isSuccess) {
+      if (data?.data) {
+        // 최근 리뷰가 있음 -> 15일이 지났든, 안지났든 뷰 모드로 + 내 리뷰 데이터 저장
+        setMyLatestReviewData(data.data);
+        setReviewMode(REVIEW_MODE.VIEW);
+      } else {
+        // 최근 리뷰가 없음 -> 폼 모드
+        setMyLatestReviewData(null);
+        setReviewMode(REVIEW_MODE.FORM_CREATE);
+      }
     } else {
-      // 최근 리뷰가 없음 -> 폼 모드
       setMyLatestReviewData(null);
       setReviewMode(REVIEW_MODE.FORM_CREATE);
     }
-  }, [data]);
+  }, [isSuccess, data, setMyLatestReviewData, setReviewMode]);
 
   return {
     myLatestReviewData,

--- a/src/app/[locale]/(main)/influencer/[influencerId]/reviews/_hooks/useReviewMutations.tsx
+++ b/src/app/[locale]/(main)/influencer/[influencerId]/reviews/_hooks/useReviewMutations.tsx
@@ -17,7 +17,6 @@ import {
   type ReviewFormData,
   type ReviewMode,
 } from '@/types/domain/reviewType';
-import { formatDateToISO } from '@/lib/date'; // 임시로 import, 백엔드에서 데이터 돌려주면 이거 없앨거임
 
 export const useReviewMutations = (
   setReviewMode: Dispatch<React.SetStateAction<ReviewMode>>,
@@ -34,8 +33,10 @@ export const useReviewMutations = (
 
   const handleCreateReview = async (influencerId: number, reviewData: ReviewFormData) => {
     try {
-      // const responseData =
-      await createReviewMutation.mutateAsync({ influencerId, reviewData });
+      const { data: responseData } = await createReviewMutation.mutateAsync({
+        influencerId,
+        reviewData,
+      });
       openModal(
         <MessageBox
           title={t('한줄리뷰가 등록되었어요')}
@@ -44,14 +45,15 @@ export const useReviewMutations = (
       );
 
       setMyLatestReviewData({
-        reviewId: 1, //이거 백엔드에서 돌려줘야함
-        isBefore15Days: true, //마지막 리뷰 15일 전인지 후인지
-        contentsRating: reviewData.contentsRating, // responseData 로 바꿔야함
-        communicationRating: reviewData.communicationRating,
-        trustRating: reviewData.trustRating,
-        reviewDate: formatDateToISO(new Date()), // 이거 백엔드에서 돌려줘야함
-        reviewContent: reviewData.content,
+        reviewId: responseData?.reviewId,
+        isBefore15Days: responseData?.isBefore15Days,
+        contentsRating: responseData?.contentsRating,
+        communicationRating: responseData?.communicationRating,
+        trustRating: responseData?.trustRating,
+        reviewDate: responseData?.reviewDate,
+        reviewContent: responseData?.reviewContent,
       });
+
       setReviewMode(REVIEW_MODE.VIEW);
     } catch {
       showErrorToast(t('한줄리뷰 생성에 실패했어요'), t('다시 시도해 주세요'));
@@ -64,8 +66,11 @@ export const useReviewMutations = (
     reviewData: ReviewFormData,
   ) => {
     try {
-      // const responseData =
-      await updateReviewMutation.mutateAsync({ influencerId, reviewId, reviewData });
+      const { data: responseData } = await updateReviewMutation.mutateAsync({
+        influencerId,
+        reviewId,
+        reviewData,
+      });
       openModal(
         <MessageBox
           title={t('한줄리뷰가 수정되었어요')}
@@ -74,13 +79,13 @@ export const useReviewMutations = (
       );
 
       setMyLatestReviewData({
-        reviewId: 1, //이거 백엔드에서 돌려줘야함
-        isBefore15Days: true, //마지막 리뷰 15일 전인지 후인지
-        contentsRating: reviewData.contentsRating, // responseData 로 바꿔야함
-        communicationRating: reviewData.communicationRating,
-        trustRating: reviewData.trustRating,
-        reviewDate: formatDateToISO(new Date()), // 이거 백엔드에서 돌려줘야함
-        reviewContent: reviewData.content,
+        reviewId: responseData?.reviewId,
+        isBefore15Days: responseData?.isBefore15Days,
+        contentsRating: responseData?.contentsRating,
+        communicationRating: responseData?.communicationRating,
+        trustRating: responseData?.trustRating,
+        reviewDate: responseData?.reviewDate,
+        reviewContent: responseData?.reviewContent,
       });
       setReviewMode(REVIEW_MODE.VIEW);
     } catch {
@@ -97,6 +102,11 @@ export const useReviewMutations = (
           buttons={[{ text: t('확인'), color: 'lime' }]}
         />,
       );
+
+      // #20241010.syjang, 내 최신 리뷰 쿼리를 invalidateQueries 적용해도 MyReview가 리렌더링이 안됨..
+      // 근데 새로고침하고 삭제하면 또 리렌더링 잘된다.. 우선 뷰 모드로 강제 전환..
+      setMyLatestReviewData(null);
+      setReviewMode(REVIEW_MODE.FORM_CREATE);
     } catch {
       showErrorToast(t('한줄리뷰 삭제에 실패했어요'), t('다시 시도해 주세요'));
     }

--- a/src/app/[locale]/(main)/influencer/[influencerId]/reviews/page.tsx
+++ b/src/app/[locale]/(main)/influencer/[influencerId]/reviews/page.tsx
@@ -27,7 +27,7 @@ export default async function InfluencerReviewListPage({
 }) {
   const { data: influencerData } = await getInfluencerData(influencerId);
   return (
-    <div className="flex h-full flex-col pb-20">
+    <div className="flex h-full flex-col">
       <section
         aria-label="인플루언서 정보"
         className="sticky top-0 flex flex-shrink-0 flex-col gap-2.5 bg-black pb-8">
@@ -37,7 +37,7 @@ export default async function InfluencerReviewListPage({
         <MyReview influencerId={parseInt(influencerId)} />
       </section>
       <Separator className="h-2 flex-shrink-0 bg-neutral-900" />
-      <section aria-label="한줄리뷰 전체 리스트" className="mt-[15px] flex-1">
+      <section aria-label="한줄리뷰 전체 리스트" className="mt-[15px] flex-1 pb-20">
         <SpecificInfluencerReviewList influencerId={parseInt(influencerId)} />
       </section>
     </div>

--- a/src/app/[locale]/auth/redirect/_hooks/useGoogleLogin.tsx
+++ b/src/app/[locale]/auth/redirect/_hooks/useGoogleLogin.tsx
@@ -34,7 +34,7 @@ export const useGoogleLogin = () => {
       // 받아온 user 정보 authStore, userStore에 저장하기
       setLogin(accessToken, member.refreshToken);
       setUser({
-        userId: member.id.toString(),
+        userId: member.id,
         nickName: member.nickName,
         email: member.email,
         birthYear: member.birthYear,

--- a/src/hooks/queries/useReviewService.ts
+++ b/src/hooks/queries/useReviewService.ts
@@ -14,6 +14,7 @@ import type {
   UpdateInfluencerReviewRequest,
   UpdateInfluencerReviewResponse,
 } from '@/types/service/reviewServiceType';
+import { useUserStore } from '@/stores/userStore';
 
 // 내 가장 최근 리뷰
 export const useMyLatestReviewForInfluencer = (influencerId: number) => {
@@ -26,11 +27,72 @@ export const useMyLatestReviewForInfluencer = (influencerId: number) => {
 
 // 인플루언서 리뷰 생성
 export const useCreateInfluencerReveiw = () => {
+  const queryClient = useQueryClient();
+  const user = useUserStore((state) => state.user);
+
   return useMutation<CreateInfluencerReviewResponse, AxiosError, CreateInfluencerReviewRequest>({
     mutationFn: reviewService.createInfluencerReview,
-    onSuccess: () => {
-      // submit할 때 돌려받은 데이터로 리액트쿼리 전체 리뷰 캐시 데이터 수정하기, 또는 백엔드에서 돌려준 데이터로..
-      // setQueryData
+    onSuccess: ({ data }, variables) => {
+      const influencerId = variables.influencerId;
+      const reviewId = data.reviewId;
+
+      // submit할 때 돌려받은 데이터로 리액트쿼리 리뷰 캐시 데이터 수정하기
+      const newReviewData = {
+        reviewId: reviewId,
+        reviewerId: user?.userId || 0,
+        reviewerNickName: user?.nickName || '',
+        averageRating: (data.contentsRating + data.communicationRating + data.trustRating) / 3,
+        contentsRating: data.contentsRating,
+        communicationRating: data.communicationRating,
+        trustRating: data.trustRating,
+        reviewDate: data.reviewDate,
+        reviewContent: data.reviewContent,
+        reviewLikeCount: 0,
+        reviewDislikeCount: 0,
+        reviewCommentsCount: 0,
+        isMyReview: true,
+        isLiked: false,
+        isDisliked: false,
+      };
+
+      // 최신순일 때
+      queryClient.setQueryData<SpecificInfluencerAllReviewsResponse>(
+        ['specificInfluencerAllReviews', influencerId, 'LATEST'],
+        (oldData) => {
+          if (!oldData) return oldData;
+          return {
+            ...oldData,
+            data: [newReviewData, ...oldData.data], // 가장 앞에 추가
+          };
+        },
+      );
+
+      // 추천순일 때
+      queryClient.setQueryData<SpecificInfluencerAllReviewsResponse>(
+        ['specificInfluencerAllReviews', influencerId, 'RECOMMENDED'],
+        (oldData) => {
+          if (!oldData) return oldData;
+
+          // reviewLikeCount-reviewDislikeCount 가 0이하가 되는 지점의 가장 앞에 추가
+          const insertIndex = oldData.data.findIndex(
+            (review) => review.reviewLikeCount - review.reviewDislikeCount <= 0,
+          );
+
+          const newData = [...oldData.data];
+          if (insertIndex === -1) {
+            // 만약 모든 리뷰의 추천 수가 0보다 크다면 맨 뒤에 추가
+            newData.push(newReviewData);
+          } else {
+            // 찾은 인덱스에 새 리뷰 삽입
+            newData.splice(insertIndex, 0, newReviewData);
+          }
+
+          return {
+            ...oldData,
+            data: newData,
+          };
+        },
+      );
     },
   });
 };

--- a/src/types/domain/userType.ts
+++ b/src/types/domain/userType.ts
@@ -1,7 +1,7 @@
 export type Gender = 'MALE' | 'FEMALE' | 'UNKNOWN' | null;
 
 export interface User {
-  userId: string; // 유저 식별자
+  userId: number; // 유저 식별자
   nickName: string;
   email: string;
   birthYear: number;


### PR DESCRIPTION
## ❗ Issue Number or Link

- #112 

## 🧰 변경 타입

- [x] ✨ feat: 새로운 기능
- [ ] 🐛 fix: 버그 수정
- [ ] ♻️ refactor: 코드 리팩토링
- [ ] 🎨 design: CSS 등 사용자 UI 디자인 변경
- [ ] 💎 style: 코드 포맷팅, 코드 변경이 없는 경우
- [ ] 📦 chore: 빌드 업무 수정, 패키지 매니저 설정, 자잘한 코드 수정
- [ ] 💬 comment: 주석 추가 및 변경
- [ ] 📚 docs: 문서 수정
- [ ] 🚑 !HOTFIX: 급하게 치명적인 버그를 고치는 경우
- [ ] 🚀 perf: 성능 개선

## 🔎 작업 내용

- 리뷰 생성/수정/삭제 시에 새로 서버에서 데이터 받아오지 않아도 setQueryData로 캐시데이터 수정하여 수정사항 반영 되도록 추가

https://github.com/user-attachments/assets/0ac92891-9ae8-4343-b97b-0bd3105a6d42



## 📢 주의 및 리뷰 요청

- 여기에 작성

## 🔗 Reference

- 해당 테스크를 수행하며 참고한 Link를 모두 작성 (Reference)
